### PR TITLE
feat: integrate external asset pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint format test run assets check
+.PHONY: setup lint format test run assets assets-cc0-lpc assets-verify check
 
 # 创建虚拟环境并安装依赖
 setup:
@@ -20,11 +20,20 @@ test:
 run:
 	uvicorn miniWorld.app:app --reload
 
-# 本地生成像素占位资源（请勿提交 assets/build/ 内容）
+# 一键仅处理 CC0 来源,本地创建占位或下载素材(不会提交到仓库)
 assets:
-	@echo "[提示] 本命令将在本地生成占位 PNG 到 assets/build/，请勿提交到仓库"
-	python assets/generators/generate_sample_tiles.py
-	python assets/generators/generate_sample_sprites.py
+	# 调用素材拉取脚本,仅处理 CC0 许可
+	python scripts/fetch_assets.py --only-cc0
+
+# 包含 CC0 与 LPC 资源,会在许可证文档写入署名提示
+assets-cc0-lpc:
+	# 调用素材拉取脚本,允许包含 LPC CC-BY-SA 资源
+	python scripts/fetch_assets.py --only-cc0 --with-lpc
+
+# 校验映射 JSON 与本地素材文件是否一致
+assets-verify:
+	# 执行校验脚本,确保映射与文件存在
+	python scripts/verify_bindings.py
 
 # 一键执行静态检查与测试
 check:

--- a/assets/external_catalog.json
+++ b/assets/external_catalog.json
@@ -1,0 +1,30 @@
+{
+  "_comment": "列出所有可选素材源及许可信息,供脚本解析时提供提示", 
+  "sources": [
+    {
+      "name": "Kenney Top-Down pack",
+      "license": "CC0",
+      "homepage": "https://kenney.nl/assets",
+      "download": "https://example.com/kenney-topdown.zip",
+      "notes": "仅使用 tilesheet_*.png, portraits_*.png 等; 解压后放入 assets/build/kenney/",
+      "_comment": "示例直链仅用于说明,实际使用时请替换为官方提供的链接"
+    },
+    {
+      "name": "Itch.io CC0 Tilesets",
+      "license": "CC0",
+      "homepage": "https://itch.io/game-assets/assets-cc0/tag-tileset",
+      "download": null,
+      "notes": "示例: 手动下载某 CC0 tileset; 把 png 放到 assets/build/itch-cc0/ 下",
+      "_comment": "download 为空表示需手动下载,脚本会创建占位"
+    },
+    {
+      "name": "OpenGameArt LPC Terrains",
+      "license": "CC-BY-SA",
+      "homepage": "https://opengameart.org/",
+      "download": null,
+      "attribution": "需在 ASSETS_LICENSES.md 标注作者与链接; 若打包再发布,需遵守相同方式共享",
+      "notes": "可选使用; 若不准备遵守 SA 条款,请在 fetch 时选择 --only-cc0",
+      "_comment": "强调共享相同许可的要求,并提示如何在脚本中排除"
+    }
+  ]
+}

--- a/assets/licenses/ASSETS_LICENSES.md
+++ b/assets/licenses/ASSETS_LICENSES.md
@@ -1,0 +1,3 @@
+# 外部素材许可证汇总
+
+当前尚未通过脚本生成具体条目。请执行 `python scripts/fetch_assets.py --dry-run` 或相关命令以创建占位内容。

--- a/assets/mapping/personas_binding.json
+++ b/assets/mapping/personas_binding.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "为六位核心角色配置头像路径,前端可按需扩展更多角色",
+  "勇者": { "avatar": "assets/build/kenney/portraits/hero_01.png" },
+  "剑士": { "avatar": "assets/build/kenney/portraits/knight_01.png" },
+  "魔导师": { "avatar": "assets/build/kenney/portraits/mage_01.png" },
+  "神官": { "avatar": "assets/build/kenney/portraits/cleric_01.png" },
+  "盗贼": { "avatar": "assets/build/kenney/portraits/rogue_01.png" },
+  "公主": { "avatar": "assets/build/kenney/portraits/princess_01.png" }
+}

--- a/assets/mapping/tileset_binding.json
+++ b/assets/mapping/tileset_binding.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "定义逻辑瓦片类型到外部图集中具体瓦片编号的映射,供前端渲染时查找",
+  "tile_size": 32,
+  "atlas_hint": "优先使用 assets/build/kenney/tilesheet.png, 如缺失则前端可退化成占位色块",
+  "bindings": {
+    "GRASS": { "atlas": "assets/build/kenney/tilesheet.png", "id": 101 },
+    "ROAD":  { "atlas": "assets/build/kenney/tilesheet.png", "id": 205 },
+    "WATER": { "atlas": "assets/build/kenney/tilesheet.png", "id": 301 },
+    "SOIL":  { "atlas": "assets/build/kenney/tilesheet.png", "id": 120 },
+    "TREE":  { "atlas": "assets/build/kenney/tilesheet.png", "id": 501 },
+    "HOUSE_BASE": { "atlas": "assets/build/kenney/tilesheet.png", "id": 620 }
+  }
+}

--- a/scripts/fetch_assets.py
+++ b/scripts/fetch_assets.py
@@ -1,0 +1,222 @@
+"""提供外部像素素材下载与占位生成功能的脚本。"""  # 模块 docstring,说明用途
+
+from __future__ import annotations  # 启用前向引用,便于类型标注
+
+import argparse  # 导入 argparse,处理命令行参数
+import hashlib  # 导入 hashlib,用于计算哈希
+import json  # 导入 json,读取目录元数据
+import logging  # 导入 logging,输出提示
+import shutil  # 导入 shutil,执行文件移动
+import sys  # 导入 sys,用于返回值
+from pathlib import Path  # 导入 Path,统一文件路径
+from tempfile import TemporaryDirectory  # 导入 TemporaryDirectory,存放临时下载文件
+from typing import Any, Iterable  # 导入类型提示
+from urllib.error import URLError  # 导入 URLError,处理下载异常
+from urllib.request import urlopen  # 导入 urlopen,下载文件
+import zipfile  # 导入 zipfile,解压压缩包
+
+logger = logging.getLogger(__name__)  # 创建模块级日志记录器
+
+CATALOG_PATH = Path(__file__).resolve().parents[1] / "assets" / "external_catalog.json"  # 定义元数据路径
+LICENSE_PATH = Path(__file__).resolve().parents[1] / "assets" / "licenses" / "ASSETS_LICENSES.md"  # 定义许可证输出路径
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:  # 定义参数解析函数
+    """解析命令行参数并返回命名空间。"""  # 函数 docstring,说明用途
+
+    parser = argparse.ArgumentParser(description="miniWorld 外部素材拉取脚本")  # 创建参数解析器
+    parser.add_argument("--only-cc0", action="store_true", help="仅处理 CC0 许可的素材源")  # 添加 only-cc0 选项
+    parser.add_argument("--with-lpc", action="store_true", help="明确允许包含 LPC CC-BY-SA 素材")  # 添加 with-lpc 选项
+    parser.add_argument("--dry-run", action="store_true", help="仅打印计划,不写入素材文件")  # 添加 dry-run 选项
+    parser.add_argument("--dest", type=Path, default=Path(__file__).resolve().parents[1] / "assets" / "build", help="指定素材输出目录")  # 添加 dest 选项
+    parser.add_argument("--allow-network", action="store_true", help="允许脚本尝试联网下载直链资源")  # 添加 allow-network 选项
+    args = parser.parse_args(list(argv) if argv is not None else None)  # 解析参数
+    return args  # 返回解析结果
+
+
+def load_catalog(path: Path) -> dict[str, Any]:  # 定义元数据加载函数
+    """读取外部素材目录 JSON 并返回字典。"""  # 函数 docstring,说明用途
+
+    with path.open("r", encoding="utf-8") as fp:  # 打开 JSON 文件
+        data = json.load(fp)  # 解析为字典
+    return data  # 返回数据
+
+
+def slugify(name: str) -> str:  # 定义名称转目录函数
+    """将素材名称转换为小写短横线形式的目录名。"""  # 函数 docstring,说明用途
+
+    safe = [ch.lower() if ch.isalnum() else "-" for ch in name]  # 将非字母数字替换为短横线
+    slug = "".join(safe).strip("-")  # 拼接并去除首尾短横线
+    return slug or "assets"  # 若结果为空则回退为默认
+
+
+def ensure_directory(path: Path, dry_run: bool) -> None:  # 定义确保目录存在的函数
+    """在非 dry-run 模式下创建目标目录。"""  # 函数 docstring,说明用途
+
+    if dry_run:  # 判断是否 dry-run
+        logger.info("dry-run: 预创建目录 %s", path)  # 打印提示
+        return  # 直接返回
+    path.mkdir(parents=True, exist_ok=True)  # 创建目录
+
+
+def create_placeholder(path: Path, message: str, dry_run: bool) -> None:  # 定义占位文件创建函数
+    """在指定目录写入占位文件以提示手动下载。"""  # 函数 docstring,说明用途
+
+    ensure_directory(path.parent, dry_run)  # 确保目录存在
+    placeholder = path.with_suffix(path.suffix + ".placeholder") if path.suffix else path / "MANUAL.placeholder"  # 计算占位文件名
+    if dry_run:  # 判断是否 dry-run
+        logger.info("dry-run: 将在 %s 写入占位提示: %s", placeholder, message)  # 输出提示
+        return  # 返回
+    with placeholder.open("w", encoding="utf-8") as fp:  # 打开占位文件
+        fp.write(message)  # 写入提示文本
+
+
+def write_license_report(sources: list[dict[str, Any]], license_path: Path, dry_run: bool, include_lpc: bool) -> None:  # 定义许可证文档生成函数
+    """根据已处理的素材源生成许可证汇总文档。"""  # 函数 docstring,说明用途
+
+    lines: list[str] = []  # 初始化行列表
+    lines.append("# 外部素材许可证汇总")  # 写入标题
+    lines.append("")  # 写入空行
+    if dry_run:  # 若为 dry-run 模式
+        lines.append("当前未拉取任何素材,以下内容仅供手动下载或正式执行时参考。")  # 写入提示
+        lines.append("")  # 添加空行
+    if not sources:  # 判断是否有素材
+        lines.append("当前未拉取任何素材,请手动下载或执行脚本去除 --dry-run 选项。")  # 写入提示
+        lines.append("需要素材时请参考 assets/external_catalog.json 中的 notes 字段。")  # 写入指引
+    else:  # 存在素材
+        cc0_only = all(src.get("license", "").upper() == "CC0" for src in sources)  # 判断是否全部 CC0
+        if cc0_only:  # 若全部 CC0
+            lines.append("全部素材均为 CC0 许可,无需额外署名,可自由在项目中使用。")  # 写入说明
+        else:  # 存在非 CC0
+            lines.append("存在非 CC0 素材,请在产品发行时附带以下署名段落。")  # 写入警告
+        lines.append("")  # 插入空行
+        for src in sources:  # 遍历素材
+            lines.append(f"## {src.get('name', '未命名来源')}")  # 写入小标题
+            lines.append("")  # 空行
+            lines.append(f"- 许可: {src.get('license', '未知许可')}")  # 写入许可
+            lines.append(f"- 官网: {src.get('homepage', '无')}")  # 写入官网
+            download = src.get("download")  # 读取下载信息
+            lines.append(f"- 下载: {download if download else '需手动下载或参考备注'}")  # 写入下载指引
+            notes = src.get("notes")  # 读取备注
+            if notes:  # 若存在备注
+                lines.append(f"- 备注: {notes}")  # 写入备注
+            attribution = src.get("attribution")  # 读取署名要求
+            if attribution:  # 若存在署名要求
+                lines.append(f"- 署名: {attribution}")  # 写入署名文本
+            lines.append("")  # 添加空行
+        if include_lpc:  # 若包含 LPC
+            lines.append("### LPC 素材署名模板")  # 写入模板标题
+            lines.append("")  # 空行
+            lines.append("本项目使用了来自 OpenGameArt LPC 系列的素材,请在发布页面附上原作者及链接,并以 CC-BY-SA 3.0 共享衍生作品。")  # 写入模板
+    content = "\n".join(lines) + "\n"  # 拼接内容
+    if dry_run:  # 判断是否 dry-run
+        logger.info("dry-run: 仍会写入许可证文档以便下游校验,内容如下:\n%s", content)  # 输出预览
+    license_path.parent.mkdir(parents=True, exist_ok=True)  # 确保目录存在
+    with license_path.open("w", encoding="utf-8") as fp:  # 打开文件写入
+        fp.write(content)  # 写入内容
+
+
+def save_binary_to_path(data: bytes, target: Path, dry_run: bool) -> None:  # 定义保存字节流的函数
+    """保存下载内容到目标路径,遵循 dry-run 逻辑。"""  # 函数 docstring,说明用途
+
+    ensure_directory(target.parent, dry_run)  # 确保目录存在
+    if dry_run:  # 判断是否 dry-run
+        logger.info("dry-run: 将在 %s 写入文件(长度 %s)", target, len(data))  # 输出提示
+        return  # 返回
+    with target.open("wb") as fp:  # 打开目标文件
+        fp.write(data)  # 写入字节流
+
+
+def maybe_download(url: str, allow_network: bool) -> bytes | None:  # 定义下载辅助函数
+    """根据 allow-network 决定是否尝试下载指定 URL。"""  # 函数 docstring,说明用途
+
+    if not allow_network:  # 若未允许联网
+        logger.warning("未开启 --allow-network,跳过下载 %s", url)  # 输出警告
+        return None  # 返回空
+    try:  # 尝试下载
+        with urlopen(url) as resp:  # 发起请求
+            data = resp.read()  # 读取全部内容
+        return data  # 返回字节
+    except URLError as exc:  # 捕获下载异常
+        logger.error("下载失败:%s", exc)  # 输出错误
+        return None  # 返回空
+
+
+def handle_source(source: dict[str, Any], args: argparse.Namespace, processed: list[dict[str, Any]]) -> None:  # 定义素材处理函数
+    """根据参数处理单个素材来源,并将成功的源记录在 processed 中。"""  # 函数 docstring,说明用途
+
+    license_name = source.get("license", "").upper()  # 读取许可名称
+    if args.only_cc0 and license_name != "CC0":  # 判断 only-cc0
+        logger.info("跳过 %s,因非 CC0", source.get("name"))  # 输出提示
+        return  # 返回
+    if license_name == "CC-BY-SA" and not args.with_lpc:  # 判断 LPC 许可
+        logger.info("跳过 %s,需加 --with-lpc 才会处理", source.get("name"))  # 输出提示
+        return  # 返回
+    dest_root: Path = args.dest  # 读取目标根目录
+    slug = slugify(source.get("name", "source"))  # 计算目录名
+    dest_dir = dest_root / slug  # 组合目录
+    download_url = source.get("download")  # 读取下载链接
+    ensure_directory(dest_dir, args.dry_run)  # 确保目录存在
+    if download_url and "example.com" in download_url:  # 若链接为示例链接
+        logger.info("检测到示例链接 %s,改为生成占位文件", download_url)  # 输出提示
+        download_url = None  # 将链接视为无效
+    if download_url:  # 若存在可用链接
+        data = maybe_download(download_url, args.allow_network)  # 尝试下载
+        if data:  # 若成功下载
+            with TemporaryDirectory() as tmp_dir_name:  # 创建临时目录
+                tmp_dir = Path(tmp_dir_name)  # 转换为 Path
+                archive_path = tmp_dir / "archive.bin"  # 定义临时文件
+                save_binary_to_path(data, archive_path, args.dry_run)  # 保存文件
+                if args.dry_run:  # 若 dry-run
+                    logger.info("dry-run: 将检测下载内容是否为 zip")  # 输出提示
+                else:  # 非 dry-run
+                    if zipfile.is_zipfile(archive_path):  # 判断是否为 zip
+                        with zipfile.ZipFile(archive_path) as zf:  # 打开压缩包
+                            for member in zf.namelist():  # 遍历文件
+                                zf.extract(member, tmp_dir)  # 解压文件
+                        for child in tmp_dir.iterdir():  # 遍历解压内容
+                            target = dest_dir / child.name  # 计算目标路径
+                            if child.is_dir():  # 若为目录
+                                if target.exists():  # 若目标存在
+                                    shutil.rmtree(target)  # 删除旧目录
+                                shutil.move(str(child), target)  # 移动目录
+                            else:  # 普通文件
+                                shutil.move(str(child), target)  # 直接移动
+                    else:  # 非 zip 文件
+                        target_file = dest_dir / archive_path.name  # 直接保存
+                        shutil.move(str(archive_path), target_file)  # 移动到目标
+                    hash_expected = source.get("sha256")  # 读取预期哈希
+                    if hash_expected:  # 若提供哈希
+                        hash_actual = hashlib.sha256(data).hexdigest()  # 计算实际哈希
+                        if hash_actual.lower() != str(hash_expected).lower():  # 比较哈希
+                            logger.warning("哈希不匹配: 预期 %s 实得 %s", hash_expected, hash_actual)  # 输出警告
+                        else:  # 哈希匹配
+                            logger.info("哈希校验通过:%s", hash_actual)  # 输出确认
+                    else:  # 没有哈希
+                        logger.warning("源 %s 未提供哈希校验,请人工确认文件完整性", source.get("name"))  # 输出警告
+            processed.append(source)  # 记录已处理来源
+            return  # 返回
+        logger.warning("未能下载 %s,将创建占位文件", source.get("name"))  # 下载失败提示
+    message = source.get("notes", "请参考 external_catalog.json 中的 notes 手动下载。")  # 读取提示信息
+    placeholder_target = dest_dir / "README.txt"  # 设置占位路径
+    create_placeholder(placeholder_target, message, args.dry_run)  # 创建占位文件
+    processed.append(source)  # 即便是占位也视作已处理,便于许可证记录
+
+
+def main(argv: Iterable[str] | None = None) -> int:  # 定义主函数
+    """执行素材拉取流程,返回退出码。"""  # 函数 docstring,说明用途
+
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")  # 初始化日志
+    args = parse_args(argv)  # 解析参数
+    catalog = load_catalog(CATALOG_PATH)  # 加载目录
+    sources: list[dict[str, Any]] = catalog.get("sources", [])  # 提取来源列表
+    processed: list[dict[str, Any]] = []  # 初始化已处理列表
+    for source in sources:  # 遍历来源
+        handle_source(source, args, processed)  # 处理素材
+    write_license_report(processed, LICENSE_PATH, args.dry_run, args.with_lpc)  # 生成许可证文档
+    logger.info("处理完成,共记录 %s 个素材源", len(processed))  # 输出总结
+    return 0  # 返回成功码
+
+
+if __name__ == "__main__":  # 判断脚本是否直接执行
+    sys.exit(main())  # 调用主函数并退出

--- a/scripts/verify_bindings.py
+++ b/scripts/verify_bindings.py
@@ -1,0 +1,104 @@
+"""校验素材映射 JSON 与本地素材文件是否完备的脚本。"""  # 模块 docstring,说明用途
+
+from __future__ import annotations  # 启用前向引用,便于类型标注
+
+import argparse  # 导入 argparse,处理命令行参数
+import json  # 导入 json,解析映射文件
+import sys  # 导入 sys,控制退出码
+from pathlib import Path  # 导入 Path,统一路径操作
+from typing import Any  # 导入 Any,用于类型标注
+
+DEFAULT_ROOT = Path(__file__).resolve().parents[1]  # 计算仓库根目录
+DEFAULT_MAPPING_DIR = DEFAULT_ROOT / "assets" / "mapping"  # 默认映射目录
+DEFAULT_BUILD_DIR = DEFAULT_ROOT / "assets" / "build"  # 默认素材生成目录
+
+
+def parse_args() -> argparse.Namespace:  # 定义参数解析函数
+    """解析命令行参数以支持自定义目录。"""  # 函数 docstring,说明用途
+
+    parser = argparse.ArgumentParser(description="校验素材映射与文件存在性")  # 创建解析器
+    parser.add_argument("--mapping-dir", type=Path, default=DEFAULT_MAPPING_DIR, help="指定映射 JSON 所在目录")  # 映射目录参数
+    parser.add_argument("--asset-root", type=Path, default=DEFAULT_ROOT, help="指定素材路径解析的根目录")  # 素材根目录参数
+    parser.add_argument("--build-dir", type=Path, default=DEFAULT_BUILD_DIR, help="指定素材实际存放目录")  # build 目录参数
+    return parser.parse_args()  # 返回解析结果
+
+
+def load_json(path: Path) -> Any:  # 定义 JSON 读取函数
+    """读取给定路径的 JSON 文件并返回解析后的对象。"""  # 函数 docstring,说明用途
+
+    with path.open("r", encoding="utf-8") as fp:  # 打开文件
+        return json.load(fp)  # 返回解析后的对象
+
+
+def validate_tilesets(mapping_dir: Path, asset_root: Path) -> list[str]:  # 定义瓦片映射校验函数
+    """校验瓦片图集映射结构与引用路径是否存在,返回错误消息列表。"""  # 函数 docstring,说明用途
+
+    tileset_path = mapping_dir / "tileset_binding.json"  # 组合瓦片映射路径
+    if not tileset_path.exists():  # 检查文件是否存在
+        return ["缺少 tileset_binding.json,需要先执行素材拉取脚本或手动创建映射。"]  # 返回错误
+    data = load_json(tileset_path)  # 读取 JSON
+    errors: list[str] = []  # 初始化错误列表
+    if "bindings" not in data:  # 检查键是否存在
+        errors.append("tileset_binding.json 缺少 bindings 字段。")  # 追加错误
+        return errors  # 直接返回
+    for tile_type, binding in data["bindings"].items():  # 遍历每个绑定
+        if not isinstance(binding, dict):  # 检查结构
+            errors.append(f"瓦片 {tile_type} 的绑定不是对象。")  # 追加错误
+            continue  # 继续下一项
+        atlas = binding.get("atlas")  # 读取图集路径
+        tile_id = binding.get("id")  # 读取瓦片编号
+        if not atlas:  # 检查 atlas
+            errors.append(f"瓦片 {tile_type} 缺少 atlas 字段。")  # 追加错误
+            continue  # 继续
+        if tile_id is None:  # 检查 id
+            errors.append(f"瓦片 {tile_type} 缺少 id 字段。")  # 追加错误
+        atlas_path = (asset_root / atlas).resolve() if not Path(atlas).is_absolute() else Path(atlas)  # 解析路径
+        if not atlas_path.exists():  # 检查文件存在
+            errors.append(f"瓦片 {tile_type} 引用的图集不存在: {atlas_path}")  # 追加错误
+    return errors  # 返回错误列表
+
+
+def validate_personas(mapping_dir: Path, asset_root: Path) -> list[str]:  # 定义角色头像校验函数
+    """校验角色头像映射结构与文件存在性,返回错误消息列表。"""  # 函数 docstring,说明用途
+
+    persona_path = mapping_dir / "personas_binding.json"  # 组合头像映射路径
+    if not persona_path.exists():  # 判断文件存在
+        return ["缺少 personas_binding.json,需要先执行素材拉取脚本或手动创建映射。"]  # 返回错误
+    data = load_json(persona_path)  # 读取 JSON
+    errors: list[str] = []  # 初始化错误列表
+    for persona, meta in data.items():  # 遍历映射
+        if persona.startswith("_"):  # 跳过注释键
+            continue  # 跳过
+        if not isinstance(meta, dict):  # 检查结构
+            errors.append(f"角色 {persona} 的配置不是对象。")  # 追加错误
+            continue  # 下一项
+        avatar = meta.get("avatar")  # 读取头像路径
+        if not avatar:  # 检查路径存在
+            errors.append(f"角色 {persona} 缺少 avatar 字段。")  # 追加错误
+            continue  # 下一项
+        avatar_path = (asset_root / avatar).resolve() if not Path(avatar).is_absolute() else Path(avatar)  # 解析路径
+        if not avatar_path.exists():  # 检查文件存在
+            errors.append(f"角色 {persona} 的头像文件不存在: {avatar_path}")  # 追加错误
+    return errors  # 返回错误列表
+
+
+def main() -> int:  # 定义主函数
+    """执行完整校验流程并返回退出码。"""  # 函数 docstring,说明用途
+
+    args = parse_args()  # 解析命令行参数
+    if not args.build_dir.exists():  # 检查素材输出目录是否存在
+        print(f"[提示] 素材输出目录 {args.build_dir} 尚未创建,校验将继续但可能出现缺失文件提示。")  # 打印提示
+    errors: list[str] = []  # 初始化错误列表
+    errors.extend(validate_tilesets(args.mapping_dir, args.asset_root))  # 校验瓦片映射
+    errors.extend(validate_personas(args.mapping_dir, args.asset_root))  # 校验头像映射
+    if errors:  # 判断是否存在错误
+        for message in errors:  # 遍历错误
+            print(f"[校验失败] {message}")  # 打印提示
+        print("需要先执行 fetch_assets.py 或将素材放入 assets/build/ 对应位置。")  # 打印总结
+        return 1  # 返回失败码
+    print("素材映射校验通过,所有引用的文件均已就绪。")  # 打印成功消息
+    return 0  # 返回成功码
+
+
+if __name__ == "__main__":  # 判断是否直接执行
+    sys.exit(main())  # 调用主函数并退出

--- a/src/miniWorld/app.py
+++ b/src/miniWorld/app.py
@@ -9,6 +9,7 @@ from typing import Any  # 导入 Any,用于注解 payload
 from fastapi import FastAPI, HTTPException, Request  # 导入 FastAPI 相关类
 from fastapi.responses import JSONResponse  # 导入 JSONResponse,自定义错误响应
 
+from .assets_api import router as assets_router  # 导入素材接口路由
 from .config import get_settings  # 导入配置加载函数
 from .models import (  # 导入数据模型
     ChatSimulateResponse,  # 聊天响应模型
@@ -40,6 +41,7 @@ logger = logging.getLogger(__name__)  # 创建模块级日志记录器
 
 settings = get_settings()  # 读取全局配置
 app = FastAPI(title=settings.app_name, debug=settings.debug)  # 创建 FastAPI 应用实例
+app.include_router(assets_router)  # 挂载素材接口路由
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]  # 计算工程根目录
 _DATA_ROOT = _PROJECT_ROOT / "data"  # 定义数据目录

--- a/src/miniWorld/assets_api.py
+++ b/src/miniWorld/assets_api.py
@@ -1,0 +1,58 @@
+"""提供素材映射读取接口的 FastAPI 路由模块。"""  # 模块 docstring,说明用途
+
+from __future__ import annotations  # 启用前向引用,便于类型标注
+
+import json  # 导入 json,读取映射文件
+import logging  # 导入 logging,记录警告
+from pathlib import Path  # 导入 Path,定位文件
+from typing import Any  # 导入 Any,用于类型标注
+
+from fastapi import APIRouter  # 导入 APIRouter,注册子路由
+
+logger = logging.getLogger(__name__)  # 创建模块级日志记录器
+
+_ROUTER = APIRouter(prefix="/assets", tags=["assets"])  # 创建带前缀的路由器
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]  # 计算项目根目录
+_MAPPING_DIR = _PROJECT_ROOT / "assets" / "mapping"  # 定义映射目录
+
+
+def _load_json(path: Path) -> dict[str, Any]:  # 定义内部 JSON 读取函数
+    """尝试从给定路径加载 JSON 文件,若失败则抛出异常。"""  # 函数 docstring,说明用途
+
+    with path.open("r", encoding="utf-8") as fp:  # 打开文件
+        return json.load(fp)  # 返回解析结果
+
+
+@_ROUTER.get("/tilesets", summary="获取瓦片图集映射", response_model=dict[str, Any])  # 注册瓦片映射接口
+async def get_tileset_bindings() -> dict[str, Any]:  # 定义异步处理函数
+    """返回瓦片与外部图集的映射 JSON,缺失时提供降级结构。"""  # 函数 docstring,说明用途
+
+    path = _MAPPING_DIR / "tileset_binding.json"  # 组合文件路径
+    if not path.exists():  # 检查文件存在
+        logger.warning("tileset_binding.json 缺失,返回降级提示")  # 输出警告
+        return {"bindings": {}, "message": "尚未准备外部瓦片素材,请执行 fetch_assets.py。"}  # 返回降级结构
+    try:  # 捕获潜在解析错误
+        data = _load_json(path)  # 尝试读取文件
+        return data  # 返回文件内容
+    except (OSError, json.JSONDecodeError) as exc:  # 捕获异常
+        logger.warning("读取 tileset_binding.json 失败:%s", exc)  # 记录警告
+        return {"bindings": {}, "message": "瓦片映射解析失败,请检查 JSON 格式。"}  # 返回降级结构
+
+
+@_ROUTER.get("/personas", summary="获取角色头像映射", response_model=dict[str, Any])  # 注册角色头像接口
+async def get_persona_bindings() -> dict[str, Any]:  # 定义异步处理函数
+    """返回角色头像映射 JSON,缺失时返回降级结构。"""  # 函数 docstring,说明用途
+
+    path = _MAPPING_DIR / "personas_binding.json"  # 组合文件路径
+    if not path.exists():  # 检查文件存在
+        logger.warning("personas_binding.json 缺失,返回降级提示")  # 输出警告
+        return {"personas": {}, "message": "尚未准备角色头像素材,请执行 fetch_assets.py。"}  # 返回降级结构
+    try:  # 捕获潜在错误
+        data = _load_json(path)  # 尝试读取文件
+        return data  # 返回文件内容
+    except (OSError, json.JSONDecodeError) as exc:  # 捕获异常
+        logger.warning("读取 personas_binding.json 失败:%s", exc)  # 记录警告
+        return {"personas": {}, "message": "角色头像映射解析失败,请检查 JSON 格式。"}  # 返回降级结构
+
+
+router = _ROUTER  # 暴露路由对象供应用挂载

--- a/tests/test_assets_api.py
+++ b/tests/test_assets_api.py
@@ -1,0 +1,58 @@
+"""测试素材映射相关 API 的行为。"""  # 模块 docstring,说明用途
+
+from __future__ import annotations  # 启用前向引用,便于类型标注
+
+import json  # 导入 json,用于写入测试文件
+from pathlib import Path  # 导入 Path,构造临时路径
+
+import pytest  # 导入 pytest,组织测试
+from fastapi.testclient import TestClient  # 导入 TestClient,调用 API
+
+from src.miniWorld import assets_api  # 导入素材 API 模块
+from src.miniWorld.app import app  # 导入应用实例
+
+client = TestClient(app)  # 创建测试客户端
+
+
+@pytest.fixture()  # 声明 pytest 固件
+def temp_mapping_dir(tmp_path: Path) -> Path:  # 定义临时映射目录固件
+    """创建并返回用于测试的临时映射目录。"""  # 函数 docstring,说明用途
+
+    mapping_dir = tmp_path / "mapping"  # 组合目录
+    mapping_dir.mkdir()  # 创建目录
+    return mapping_dir  # 返回目录
+
+
+def test_assets_api_returns_mappings(monkeypatch: pytest.MonkeyPatch, temp_mapping_dir: Path) -> None:  # 定义测试函数
+    """当映射文件存在时,API 应返回完整 JSON。"""  # 函数 docstring,说明用途
+
+    tileset_path = temp_mapping_dir / "tileset_binding.json"  # 组合瓦片映射路径
+    personas_path = temp_mapping_dir / "personas_binding.json"  # 组合角色映射路径
+    tileset_data = {  # 构造瓦片数据
+        "tile_size": 16,  # 指定瓦片尺寸
+        "bindings": {"GRASS": {"atlas": "assets/build/demo.png", "id": 1}},  # 定义映射
+    }  # 结束字典
+    personas_data = {"勇者": {"avatar": "assets/build/hero.png"}}  # 构造角色数据
+    tileset_path.write_text(json.dumps(tileset_data), encoding="utf-8")  # 写入瓦片文件
+    personas_path.write_text(json.dumps(personas_data), encoding="utf-8")  # 写入角色文件
+    monkeypatch.setattr(assets_api, "_MAPPING_DIR", temp_mapping_dir)  # 覆盖映射目录
+    response_tiles = client.get("/assets/tilesets")  # 调用瓦片接口
+    response_personas = client.get("/assets/personas")  # 调用角色接口
+    assert response_tiles.status_code == 200  # 断言状态码
+    assert response_personas.status_code == 200  # 断言状态码
+    assert response_tiles.json()["bindings"]["GRASS"]["id"] == 1  # 校验返回内容
+    assert response_personas.json()["勇者"]["avatar"] == "assets/build/hero.png"  # 校验返回内容
+
+
+def test_assets_api_handles_missing_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:  # 定义缺失文件测试
+    """当映射缺失时,API 应返回降级提示而不是错误。"""  # 函数 docstring,说明用途
+
+    monkeypatch.setattr(assets_api, "_MAPPING_DIR", tmp_path)  # 将映射目录指向空目录
+    tiles_response = client.get("/assets/tilesets")  # 调用瓦片接口
+    personas_response = client.get("/assets/personas")  # 调用角色接口
+    assert tiles_response.status_code == 200  # 断言状态码
+    assert personas_response.status_code == 200  # 断言状态码
+    assert tiles_response.json()["bindings"] == {}  # 降级结构应为空绑定
+    assert "message" in tiles_response.json()  # 应包含提示信息
+    assert personas_response.json()["personas"] == {}  # 降级结构应为空角色映射
+    assert "message" in personas_response.json()  # 应包含提示信息

--- a/tests/test_fetch_and_verify.py
+++ b/tests/test_fetch_and_verify.py
@@ -1,0 +1,62 @@
+"""测试素材下载脚本与校验脚本的核心行为。"""  # 模块 docstring,说明用途
+
+from __future__ import annotations  # 启用前向引用,便于类型标注
+
+import json  # 导入 json,构造伪元数据
+import sys  # 导入 sys,以便修改 argv
+from pathlib import Path  # 导入 Path,构造临时路径
+
+import pytest  # 导入 pytest,组织测试
+
+from scripts import fetch_assets, verify_bindings  # 导入待测脚本
+
+
+def test_fetch_assets_dry_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:  # 定义 dry-run 测试
+    """dry-run 模式下脚本应生成许可证文档并提示手动下载。"""  # 函数 docstring,说明用途
+
+    catalog = {"sources": [{"name": "Test CC0", "license": "CC0", "download": None, "notes": "手动"}]}  # 构造目录数据
+    catalog_path = tmp_path / "catalog.json"  # 定义目录文件路径
+    license_path = tmp_path / "licenses.md"  # 定义许可证文件路径
+    catalog_path.write_text(json.dumps(catalog), encoding="utf-8")  # 写入目录文件
+    monkeypatch.setattr(fetch_assets, "CATALOG_PATH", catalog_path)  # 覆盖目录路径
+    monkeypatch.setattr(fetch_assets, "LICENSE_PATH", license_path)  # 覆盖许可证路径
+    exit_code = fetch_assets.main(["--dry-run", "--only-cc0", "--dest", str(tmp_path / "build")])  # 执行脚本
+    assert exit_code == 0  # 断言成功
+    content = license_path.read_text(encoding="utf-8")  # 读取许可证内容
+    assert "当前未拉取任何素材" in content  # 断言包含提示
+    assert "notes" in catalog_path.read_text(encoding="utf-8")  # 确认目录仍可被读取
+
+
+def test_verify_bindings_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:  # 定义校验成功测试
+    """当映射与文件匹配时,校验脚本应返回成功。"""  # 函数 docstring,说明用途
+
+    root = tmp_path / "project"  # 定义根目录
+    mapping_dir = root / "assets" / "mapping"  # 定义映射目录
+    build_dir = root / "assets" / "build" / "kenney"  # 定义素材目录
+    mapping_dir.mkdir(parents=True)  # 创建映射目录
+    build_dir.mkdir(parents=True)  # 创建素材目录
+    atlas_path = build_dir / "tilesheet.png"  # 定义图集文件
+    persona_path = root / "assets" / "build" / "kenney" / "hero.png"  # 定义头像文件
+    atlas_path.write_text("", encoding="utf-8")  # 创建空文件
+    persona_path.write_text("", encoding="utf-8")  # 创建空文件
+    tileset_data = {"tile_size": 32, "bindings": {"GRASS": {"atlas": "assets/build/kenney/tilesheet.png", "id": 1}}}  # 构造瓦片映射
+    personas_data = {"勇者": {"avatar": "assets/build/kenney/hero.png"}}  # 构造角色映射
+    (mapping_dir / "tileset_binding.json").write_text(json.dumps(tileset_data), encoding="utf-8")  # 写入瓦片文件
+    (mapping_dir / "personas_binding.json").write_text(json.dumps(personas_data), encoding="utf-8")  # 写入角色文件
+    monkeypatch.setattr(sys, "argv", ["verify", "--mapping-dir", str(mapping_dir), "--asset-root", str(root), "--build-dir", str(root / "assets" / "build")])  # 设置命令行参数
+    exit_code = verify_bindings.main()  # 执行脚本
+    captured = capsys.readouterr()  # 捕获输出
+    assert exit_code == 0  # 断言成功
+    assert "校验通过" in captured.out  # 确认输出
+
+
+def test_verify_bindings_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:  # 定义缺失文件测试
+    """当映射缺失时,校验脚本应返回非零并输出提示。"""  # 函数 docstring,说明用途
+
+    mapping_dir = tmp_path / "mapping"  # 定义映射目录
+    mapping_dir.mkdir()  # 创建目录
+    monkeypatch.setattr(sys, "argv", ["verify", "--mapping-dir", str(mapping_dir), "--asset-root", str(tmp_path), "--build-dir", str(tmp_path / "build")])  # 设置命令行参数
+    exit_code = verify_bindings.main()  # 执行脚本
+    captured = capsys.readouterr()  # 捕获输出
+    assert exit_code == 1  # 断言失败码
+    assert "缺少" in captured.out  # 检查输出包含提示


### PR DESCRIPTION
## Summary
- add catalog, mapping, and license placeholders for external pixel assets
- implement fetch_assets and verify_bindings scripts plus read-only assets API routes
- document the asset pipeline, new Makefile targets, and cover flows with pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db6918e66483289415045efd653432